### PR TITLE
Set state changed for weapon's AttributeManager in StatTrak logic

### DIFF
--- a/source/InventorySimulator/Extensions/CCSPlayerControllerExtensions.cs
+++ b/source/InventorySimulator/Extensions/CCSPlayerControllerExtensions.cs
@@ -416,6 +416,7 @@ public static class CCSPlayerControllerExtensions
             "kill eater",
             statTrak
         );
+        Utilities.SetStateChanged(weapon, "CBasePlayerWeapon", "m_AttributeManager");
         Api.SendStatTrakIncrement(self.SteamID, item.Uid.Value);
     }
 

--- a/source/InventorySimulator/Extensions/CEconItemViewExtensions.cs
+++ b/source/InventorySimulator/Extensions/CEconItemViewExtensions.cs
@@ -30,7 +30,7 @@ public static class CEconItemViewExtensions
         if (steamId != null)
             self.AccountID = new CSteamID(steamId.Value).GetAccountID().m_AccountID;
         if (isMelee)
-            self.EntityQuality = 3;
+            self.EntityQuality = item.Stattrak >= 0 ? 9 : 3;
         else
             self.EntityQuality = item.Stattrak >= 0 ? 9 : 4;
         if (item.Nametag != null)

--- a/source/InventorySimulator/Extensions/CEconItemViewExtensions.cs
+++ b/source/InventorySimulator/Extensions/CEconItemViewExtensions.cs
@@ -30,7 +30,7 @@ public static class CEconItemViewExtensions
         if (steamId != null)
             self.AccountID = new CSteamID(steamId.Value).GetAccountID().m_AccountID;
         if (isMelee)
-            self.EntityQuality = item.Stattrak >= 0 ? 9 : 3;
+            self.EntityQuality = 3;
         else
             self.EntityQuality = item.Stattrak >= 0 ? 9 : 4;
         if (item.Nametag != null)


### PR DESCRIPTION
There is a problem with this plugin: the counter function does not work and always stays at zero. This commit fixes the issue.

1. Adjust the logic for obtaining EntityQuality values for melee and non-melee StatTrak equipment.
2. Add property manager state change notification for StatTrak weapons.