### PR TITLE
Add optional random StatTrak base values on inventory initialization

### DIFF
--- a/source/InventorySimulator/Extensions/CCSPlayerControllerExtensions.cs
+++ b/source/InventorySimulator/Extensions/CCSPlayerControllerExtensions.cs
@@ -84,6 +84,7 @@ public static class CCSPlayerControllerExtensions
         if (response != null)
         {
             var inventory = new PlayerInventory(response);
+            inventory.ApplyRandomStatTrakInitialValues(self.SteamID);
             if (existing != null)
                 inventory.WeaponWearCache = existing.WeaponWearCache;
             inventory.InitializeWearOverrides();

--- a/source/InventorySimulator/InventorySimulator.cs
+++ b/source/InventorySimulator/InventorySimulator.cs
@@ -39,9 +39,16 @@ public partial class InventorySimulator : BasePlugin
     public void OnFileChanged(object? _, string value)
     {
         if (Inventories.Load(value))
+        {
             foreach (var player in Utilities.GetPlayers().Where(p => !p.IsBot))
+            {
                 if (Inventories.TryGet(player.SteamID, out var inventory))
+                {
+                    inventory.ApplyRandomStatTrakInitialValues(player.SteamID);
                     player.GetState().Inventory = inventory;
+                }
+            }
+        }
     }
 
     public void OnIsRequireInventoryChanged(object? _, bool value)

--- a/source/InventorySimulator/Models/InventoryItem.cs
+++ b/source/InventorySimulator/Models/InventoryItem.cs
@@ -33,6 +33,9 @@ public class InventoryItem
     [JsonPropertyName("stattrak")]
     public int? Stattrak { get; set; }
 
+    [JsonIgnore]
+    public bool RandomStatTrakBaseApplied { get; set; }    
+
     [JsonPropertyName("stickers")]
     public List<StickerItem>? Stickers { get; set; }
 

--- a/source/InventorySimulator/Models/PlayerInventory.cs
+++ b/source/InventorySimulator/Models/PlayerInventory.cs
@@ -17,6 +17,63 @@ public class PlayerInventory(EquippedV4Response data)
 
     public Dictionary<(int paint, float wear), (ushort def, string stickers)> WeaponWearCache = [];
 
+    private static readonly object RandomStatTrakLock = new();
+    private static readonly Random RandomStatTrakRng = new();
+
+    private static readonly int[] RandomStatTrakBasePool =
+    [
+        11111,69,420,357,1337,2024,4096,1471,6543,51264,84231,2348,8756,4321
+    ];
+
+    private static readonly Dictionary<(ulong SteamID, int Uid), int> RandomStatTrakOffsets = [];
+
+    public void ApplyRandomStatTrakInitialValues(ulong steamId)
+    {
+        if (!ConVars.IsStatTrakRandomEnabled.Value)
+            return;
+
+        lock (RandomStatTrakLock)
+        {
+            void Apply(InventoryItem? item)
+            {
+                if (item == null)
+                    return;
+
+                if (item.Stattrak == null || item.Stattrak < 0)
+                    return;
+
+                if (item.Uid == null)
+                    return;
+
+                if (item.RandomStatTrakBaseApplied)
+                    return;
+
+                var key = (steamId, item.Uid.Value);
+
+                if (!RandomStatTrakOffsets.TryGetValue(key, out int offset))
+                {
+                    offset = RandomStatTrakBasePool[
+                        RandomStatTrakRng.Next(RandomStatTrakBasePool.Length)
+                    ];
+
+                    RandomStatTrakOffsets[key] = offset;
+                }
+
+                item.Stattrak += offset;
+                item.RandomStatTrakBaseApplied = true;
+            }
+
+            foreach (var item in _data.CTWeapons.Values)
+                Apply(item);
+
+            foreach (var item in _data.TWeapons.Values)
+                Apply(item);
+
+            foreach (var item in _data.Knives.Values)
+                Apply(item);
+        }
+    }
+
     public static PlayerInventory Empty() => new(new());
 
     public void InitializeWearOverrides()

--- a/source/InventorySimulator/Models/PlayerInventory.cs
+++ b/source/InventorySimulator/Models/PlayerInventory.cs
@@ -20,11 +20,6 @@ public class PlayerInventory(EquippedV4Response data)
     private static readonly object RandomStatTrakLock = new();
     private static readonly Random RandomStatTrakRng = new();
 
-    private static readonly int[] RandomStatTrakBasePool =
-    [
-        11111,69,420,357,1337,2024,4096,1471,6543,51264,84231,2348,8756,4321
-    ];
-
     private static readonly Dictionary<(ulong SteamID, int Uid), int> RandomStatTrakOffsets = [];
 
     public void ApplyRandomStatTrakInitialValues(ulong steamId)
@@ -52,10 +47,7 @@ public class PlayerInventory(EquippedV4Response data)
 
                 if (!RandomStatTrakOffsets.TryGetValue(key, out int offset))
                 {
-                    offset = RandomStatTrakBasePool[
-                        RandomStatTrakRng.Next(RandomStatTrakBasePool.Length)
-                    ];
-
+                    offset = RandomStatTrakRng.Next(1, 10001);
                     RandomStatTrakOffsets[key] = offset;
                 }
 

--- a/source/InventorySimulator/Services/ConVars.cs
+++ b/source/InventorySimulator/Services/ConVars.cs
@@ -106,6 +106,12 @@ public static class ConVars
         true
     );
 
+    public static readonly FakeConVar<bool> IsStatTrakRandomEnabled = new(
+        "invsim_stattrak_random_enabled",
+        "Enable random StatTrak base values on inventory initialization.",
+        false
+    ); 
+
     public static readonly FakeConVar<bool> IsFallbackTeam = new(
         "invsim_fallback_team",
         "Allow using skins from any team (prioritizes current team first).",


### PR DESCRIPTION
Adds an optional feature to randomize the initial StatTrak values of inventory items.

Since StatTrak progress is not persisted in local CSS environments, counters are reset whenever an inventory is reloaded. Enabling this option assigns a random starting value to supported items, making inventories feel more natural during gameplay.

Use `true` or `false` to enable or disable the feature (default: `false`).

ConVar:

```text
invsim_stattrak_random_enabled
```

Existing StatTrak values are preserved and only receive a one-time random offset during inventory initialization.